### PR TITLE
Set root's shell to /bin/sh to fix Packer failure

### DIFF
--- a/resources/installerconfig
+++ b/resources/installerconfig
@@ -36,6 +36,9 @@ EOF
 
 configure_root_user() {
   echo "$ROOT_PASSWORD" | pw usermod root -h 0
+  # FreeBSD before 14.0 use csh as a default shell for root. Packer generates
+  # commands like `foo; BAR=bar BAZ=baz bar` which fails on csh.
+  pw usermod -n root -s /bin/sh
 }
 
 configure_timezone() {


### PR DESCRIPTION
FreeBSD before 14.0 use csh as a default shell for root. Packer generates commands like `foo; BAR=bar BAZ=baz bar` which fails on csh with a next error on FreeBSD versions 13.X and earlier.

PACKER_BUILDER_TYPE=qemu: Command not found. error.

https://cgit.freebsd.org/src/commit/?id=d410b585b6f0